### PR TITLE
Fix link to 'Creating new fragments' doc

### DIFF
--- a/content/syna/fragments/_index/content.md
+++ b/content/syna/fragments/_index/content.md
@@ -7,4 +7,4 @@ title = "Fragment showcase"
 
 List of all currently available default fragments in Syna. You
 can learn how to develop your own fragment by following [Creating new
-fragments](https://github.com/okkur/syna/blob/master/docs/README.md#creating-new-fragments).
+fragments]({{< ref "fragments-implementation" >}}#creating-new-fragments).


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  
If this is your first time, read our [contributing guidelines](/CONTRIBUTING.md).
-->
**What this PR does / why we need it**:
Fixes the link to `Creating new fragments` on [this page](https://about.okkur.org/syna/fragments/).
<!--
**Which issue this PR fixes** *(optional - uncomment and add issue)*:
fixes #0
-->